### PR TITLE
Remove gazebo2

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -48,7 +48,7 @@ Depends: libignition-cmake2-dev,
 	 qtquickcontrols2-5-dev,
 	 libqt5core5a,
 	 libignition-launch2 (= ${binary:Version}),
-	 ignition-gazebo2,
+	 ignition-gazebo3,
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Robotics Launch Library - Launch libraries


### PR DESCRIPTION
Oops, `launch2` has been pulling `gazebo2` and `gazebo3`

```
$ apt-cache depends libignition-launch2-dev 
libignition-launch2-dev
  Depends: libignition-cmake2-dev
  Depends: libignition-common3-dev
  Depends: libignition-gazebo3-dev
  Depends: libignition-gui3-dev
  Depends: libignition-msgs5-dev
  Depends: libignition-plugin-dev
  Depends: libignition-tools-dev
  Depends: libignition-transport8-dev
  Depends: libtinyxml2-dev
  Depends: libwebsockets-dev
  Depends: qtquickcontrols2-5-dev
  Depends: libqt5core5a
  Depends: libignition-launch2
  Depends: ignition-gazebo2
    ignition-gazebo2:i386
```