### PR TITLE
Remove ignition-gazebo3

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -48,8 +48,7 @@ Depends: libignition-cmake2-dev,
 	 qtquickcontrols2-5-dev,
 	 libqt5core5a,
 	 libignition-launch2 (= ${binary:Version}),
-	 ignition-gazebo3,
-         ${misc:Depends}
+   ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Robotics Launch Library - Launch libraries
   Ignition Common is a component in the ignition framework, a set of libraries

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -48,7 +48,7 @@ Depends: libignition-cmake2-dev,
 	 qtquickcontrols2-5-dev,
 	 libqt5core5a,
 	 libignition-launch2 (= ${binary:Version}),
-   ${misc:Depends}
+         ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Robotics Launch Library - Launch libraries
   Ignition Common is a component in the ignition framework, a set of libraries


### PR DESCRIPTION
#1 was a bad idea, because the `ignition-gazebo3` package doesn't exist:

`E: Package 'ignition-gazebo3' has no installation candidate`